### PR TITLE
recommendation eslint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "standard.vscode-standard"
+        "dbaeumer.vscode-eslint"
     ]
 }


### PR DESCRIPTION
Hi Supergiovane,

the standard VSCode extension is buggy, I would recommend you to use the eslint extension.
Eslint is better maintained and in the error messages, you can find the link to the online help.
Thanks to the file [.eslintrc](https://github.com/Supergiovane/node-red-contrib-knx-ultimate/blob/648bb807737257d35e8c1cdc6f1f7dfe75556810/.eslintrc) eslint will use the standard js rules.

 