### PR TITLE
Add griesser object

### DIFF
--- a/KNXEngine/dptlib/dpt60001.js
+++ b/KNXEngine/dptlib/dpt60001.js
@@ -261,7 +261,11 @@ exports.basetype = {
   bitlength: 4 * 8 + 2 * 6 + 1 * 10,
   valuetype: 'composite',
   desc: 'Commands for solar shading actors',
-  help: ''
+  help: `// Sample of 60001.
+  // Now are only  the local operation implemented.
+  // For example, for 60001, set the sector 42 localy up.  
+  msg.payload = { command: "operation code", data: ["localoperation", "long up"], sectors: [42] };
+  return msg;`
 }
 
 exports.subtypes = {

--- a/KNXEngine/dptlib/dpt60001.js
+++ b/KNXEngine/dptlib/dpt60001.js
@@ -1,0 +1,272 @@
+const knxLog = require('./../KnxLog')
+
+function toRadix (value, radix) {
+  if (!Number.isSafeInteger(value)) {
+    knxLog.get().error('value must be a safe integer')
+  }
+
+  const digits = Math.ceil(64 / Math.log2(radix))
+  const twosComplement = value < 0
+    ? BigInt(radix) ** BigInt(digits) + BigInt(value)
+    : value
+
+  return twosComplement.toString(radix).padStart(digits, '0')
+}
+
+function griesserSectorCode (Byte0, Byte1) {
+  const SectorCode = Byte0 + (Byte1 & 3) * 256
+  return SectorCode
+}
+
+function griesserCommandCode (Byte1) {
+  const command = (Byte1 / 4) >> 0
+  return command
+}
+
+function griesserParameter (command, Byte2, Byte3, Byte4, Byte5) {
+  let commandOperation
+  switch (command) {
+    case 1: // drive command
+      switch (Byte2 & 31) {
+        case 0: return 'no driving movement'
+        case 1: return 'upper end position'
+        case 2: return 'lower end position'
+        case 3:
+          if ((Byte3 >= 1) & (Byte3 <= 4)) {
+            return 'fixed position P' + Byte3 + ' approach'
+          } else {
+            return 'Unknown value for Pn ' + Byte3
+          }
+        default:
+          return 'Unknown drive command' + Byte2 & 31
+      }
+    case 4: // set/delete lock
+      if (Byte2 === 0) {
+        return 'no lock'
+      } else {
+        switch (Byte2 & 3) {
+          case 1: return 'driving command'
+          case 2: return 'button lock'
+          case 3: return 'driving command- and button lock'
+        }
+        if (Byte3 === 0) {
+          return 'delete lock'
+        } else {
+          return 'set lock'
+        }
+      }
+    case 5: // operation code
+      if (Byte2 <= 6) {
+        commandOperation = 'groupoperation'
+      } else if (Byte2 >= 128 && Byte2 <= 134) {
+        commandOperation = 'localoperation'
+      } else {
+        commandOperation = 'unknown command Byte3 for ' + Byte2
+      }
+      if ((Byte2 & 127) === 0) {
+        return [commandOperation, 'long up']
+      } else if ((Byte2 & 127) === 1) {
+        return [commandOperation, 'long down']
+      } else if ((Byte2 & 127) === 2) {
+        return [commandOperation, 'short up']
+      } else if ((Byte2 & 127) === 3) {
+        return [commandOperation, 'short down']
+      } else if ((Byte2 & 127) === 4) {
+        return [commandOperation, 'stop']
+      } else if ((Byte2 & 127) === 5) {
+        return [commandOperation, 'long-short up']
+      } else if ((Byte2 & 127) === 6) {
+        return [commandOperation, 'long-short down']
+      } else {
+        return [commandOperation, 'unknown command Byte3 for ' + Byte2]
+      }
+    case 22: // driving range limits for automatic button commands
+      return ['min. angle: ' + Byte2, 'max. angle: ' + Byte3, 'min. height: ' + Byte4, 'max. height: ' + Byte5]
+    default: return 'unknown value for command: ' + command
+  }
+}
+
+function griesserSectors (SectorCode) {
+  let SectorMin, SectorMax, dA, a, SectorCodeMin, SectorCodeMax
+  dA = 1
+  a = SectorCode
+  if (a > 0) {
+    while ((a & 1) === 0) {
+      a = (a / 2) >> 0
+      dA = dA * 2
+    }
+    dA = dA - 1
+    SectorMin = SectorCode - dA
+    SectorMax = SectorCode + dA
+  } else {
+    SectorMin = 0
+    SectorMax = 0
+  }
+  if (SectorMin === 0) {
+    SectorCodeMin = 0
+  } else {
+    SectorCodeMin = (((SectorMin - 1) / 2) >> 0) + 1
+  }
+  if (SectorMax === 0) {
+    SectorCodeMax = 0
+  } else {
+    SectorCodeMax = (((SectorMax - 1) / 2) >> 0) + 1
+  }
+  if (SectorCodeMax === SectorCodeMin) {
+    return [SectorCodeMin]
+  } else {
+    const Sectors = []
+    for (let i = SectorCodeMin; i <= SectorCodeMax; i++) {
+      Sectors.push(i)
+    }
+    return Sectors
+  }
+}
+
+function griesserSectorToSectorCode (sectors) {
+  if (sectors.length === 1) {
+    return sectors[0] + sectors[0] - 1
+  } else {
+    return Math.min(...sectors) + Math.max(...sectors) - 1
+  }
+}
+
+function griesserCommandToCommandCode (command) {
+  switch (command) {
+    case 'operation code': return 5
+    default: knxLog.get().error('not implemented yet: ' + command)
+  }
+}
+
+function griesserCommandToCommandCodeP1 (command) {
+  switch (command) {
+    case 'long up': return 128
+    case 'long down': return 129
+    case 'short up': return 130
+    case 'short down': return 131
+    case 'stop': return 132
+    case 'long-short up': return 133
+    case 'long-short down': return 134
+    default: knxLog.get().error('unknown command: ' + command)
+  }
+}
+
+function griesserCommand (command) {
+  switch (command) {
+    case 1: return 'drive command'
+    case 2: return 'value correction'
+    case 3: return 'automatic state'
+    case 4: return 'set/delete lock'
+    case 5: return 'operation code'
+    case 6: return 'set scene'
+    case 7: return 'special command'
+    case 8: return 'date'
+    case 9: return 'sync time'
+    case 10: return 'sensor reading notification'
+    case 11: return 'bus monitoring'
+    case 16: return 'driving range limits for safety drive commands'
+    case 17: return 'driving range limits for safety drive commands'
+    case 19: return 'driving range limits for safety drive commands'
+    case 20: return 'driving range limits for safety drive commands'
+    case 22: return 'driving range limits for automatic drive commands'
+    case 23: return 'driving range limits for automatic drive commands'
+    case 24: return 'driving range limits for automatic drive commands'
+    default: return 'unknown value for function: ' + command
+  }
+}
+
+function griesserPrio (prio, command) {
+  const prioCommand = ((command & 224) / 32) >> 0
+  if ((((prio & 252) / 4) >> 0) === 0) {
+    switch (prioCommand) {
+      case 0: return 'border command'
+      case 1: return 'automatic command'
+      case 3: return 'priority command'
+      case 4: return 'warning command'
+      case 5: return 'security command'
+      case 6: return 'danger command'
+      default: return 'unknown priority' + prioCommand
+    }
+  } else {
+    return '-'
+  }
+}
+
+// Send to BUS
+exports.formatAPDU = function (value) {
+  if (!value) {
+    knxLog.get().error('DPT60001: cannot write null value')
+  } else {
+    if (typeof value === 'object' &&
+    Object.prototype.hasOwnProperty.call(value, 'command') &&
+    Object.prototype.hasOwnProperty.call(value, 'data') &&
+    Object.prototype.hasOwnProperty.call(value, 'sectors') &&
+    value.data[0] === 'localoperation'
+    ) {
+      const sectorCode = griesserSectorToSectorCode(value.sectors)
+      const commandCode = griesserCommandToCommandCode(value.command)
+      const p1 = griesserCommandToCommandCodeP1(value.data[1])
+      const bufferTotal = Buffer.alloc(6)
+      bufferTotal[0] = parseInt(toRadix(sectorCode, 2).slice(-8), 2)
+      bufferTotal[1] = parseInt(toRadix(commandCode, 2).slice(-6) + toRadix(sectorCode, 2).slice(-10, -8), 2)
+      bufferTotal[2] = parseInt(toRadix(p1, 2).slice(-8), 2)
+      return bufferTotal
+    } else {
+      knxLog.get().error('DPT60001: Must supply an value {command:"operation code", data:["localoperation", "long up"], sectors:[159]}')
+    }
+  }
+}
+
+// RX from BUS
+exports.fromBuffer = function (buf) {
+  if (buf.length !== 6) {
+    knxLog
+      .get()
+      .warn(
+        'DPTGriesser.fromBuffer: buf should be 6 bytes long (got %d bytes)',
+        buf.length
+      )
+    return null
+  } else {
+    const hexToDecimal = (hex) => parseInt(hex, 16)
+    const bufTotale = buf.toString('hex')
+    const Byte0 = hexToDecimal(bufTotale.slice(0, 2))
+    const Byte1 = hexToDecimal(bufTotale.slice(2, 4))
+    const Byte2 = hexToDecimal(bufTotale.slice(4, 6))
+    const Byte3 = hexToDecimal(bufTotale.slice(6, 8))
+    const Byte4 = hexToDecimal(bufTotale.slice(8, 10))
+    const Byte5 = hexToDecimal(bufTotale.slice(10, 12))
+    const sectorCode = griesserSectorCode(Byte0, Byte1)
+    const commandCode = griesserCommandCode(Byte1, Byte2)
+
+    return {
+      Byte0,
+      Byte1,
+      Byte2,
+      Byte3,
+      Byte4,
+      Byte5,
+      sectorCode,
+      commandCode,
+      sectors: griesserSectors(sectorCode),
+      prio: griesserPrio(Byte1, Byte2),
+      command: griesserCommand(commandCode),
+      data: griesserParameter(commandCode, Byte2, Byte3, Byte4, Byte5)
+    }
+  }
+}
+
+// DPT Griesser Object basetype info
+exports.basetype = {
+  bitlength: 4 * 8 + 2 * 6 + 1 * 10,
+  valuetype: 'composite',
+  desc: 'Commands for solar shading actors',
+  help: ''
+}
+
+exports.subtypes = {
+  '001': {
+    desc: 'DPT_Griesser_Object',
+    name: 'Griesser Object'
+  }
+}


### PR DESCRIPTION
Hi Supergiovane

the first draft implementation for the Griesser object is done.
I have only added the encoder for local operation, for the other functions I need first more reverse engineering.

I have some questions:
1) Which DTP number should I use? Is dpt60001 fine?
2) What can I do better?
3) Do you have any questions?


[In this excel](https://github.com/Supergiovane/node-red-contrib-knx-ultimate/files/9974928/Griesser.all.IT.xlsx) you can find a real-world recording over 1 year (filtered on unique telegrams), with the commands in Italian, exported from a Griesser tool.

And here is my testing flow:
```json
[{"id":"145a8b8a81ea42d2","type":"debug","z":"39fe313.1404dce","name":"debug 1","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"true","targetType":"full","statusVal":"","statusType":"auto","x":860,"y":100,"wires":[]},{"id":"1c93b0365f07cb53","type":"function","z":"39fe313.1404dce","name":"function 2","func":"msg.writeraw = Buffer.from(msg.payload, 'hex');\nmsg.bitlenght = 48;\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":400,"y":100,"wires":[["3660cac14f7b3262"]]},{"id":"c2cb6a2a8384e1c2","type":"inject","z":"39fe313.1404dce","name":"","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"601002020000","payloadType":"str","x":200,"y":100,"wires":[["1c93b0365f07cb53"]]},{"id":"daa3576b2bbacaa5","type":"function","z":"39fe313.1404dce","name":"up","func":"msg.payload = { command: \"operation code\", data: [\"localoperation\", \"long up\"], sectors: [msg.payload] };\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":390,"y":340,"wires":[["3660cac14f7b3262"]]},{"id":"d0c0b2b3a792077a","type":"inject","z":"39fe313.1404dce","name":"","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"DD0423040000","payloadType":"str","x":200,"y":160,"wires":[["1c93b0365f07cb53"]]},{"id":"57a91a7a2f5b2c78","type":"inject","z":"39fe313.1404dce","name":"","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"205800FF00FF","payloadType":"str","x":200,"y":220,"wires":[["1c93b0365f07cb53"]]},{"id":"deb6f12294c9d1ac","type":"inject","z":"39fe313.1404dce","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"159","payloadType":"num","x":210,"y":340,"wires":[["daa3576b2bbacaa5"]]},{"id":"3660cac14f7b3262","type":"knxUltimate","z":"39fe313.1404dce","server":"a07057ec2d3520f1","topic":"5/5/5","outputtopic":"","dpt":"60001.001","initialread":0,"notifyreadrequest":false,"notifyresponse":false,"notifywrite":true,"notifyreadrequestalsorespondtobus":false,"notifyreadrequestalsorespondtobusdefaultvalueifnotinitialized":"0","listenallga":false,"name":"","outputtype":"write","outputRBE":true,"inputRBE":false,"formatmultiplyvalue":1,"formatnegativevalue":"leave","formatdecimalsvalue":999,"passthrough":"no","x":620,"y":100,"wires":[["145a8b8a81ea42d2"]]},{"id":"983c0df3db7328d6","type":"inject","z":"39fe313.1404dce","name":"","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"3D1580000000","payloadType":"str","x":200,"y":280,"wires":[["1c93b0365f07cb53"]]},{"id":"028652cd81b9a5f9","type":"function","z":"39fe313.1404dce","name":"down","func":"msg.payload = { command: \"operation code\", data: [\"localoperation\", \"long down\"], sectors: [msg.payload] };\nreturn msg;","outputs":1,"noerr":0,"initialize":"","finalize":"","libs":[],"x":390,"y":380,"wires":[["3660cac14f7b3262"]]},{"id":"1d2e2bedab7eedab","type":"inject","z":"39fe313.1404dce","name":"","props":[{"p":"payload"},{"p":"topic","vt":"str"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"159","payloadType":"num","x":210,"y":380,"wires":[["028652cd81b9a5f9"]]},{"id":"a07057ec2d3520f1","type":"knxUltimate-config","host":"224.0.23.12","port":"3671","physAddr":"15.15.22","hostProtocol":"Multicast","suppressACKRequest":false,"csv":"","KNXEthInterface":"Auto","KNXEthInterfaceManuallyInput":"","statusDisplayLastUpdate":true,"statusDisplayDeviceNameWhenALL":true,"statusDisplayDataPoint":false,"stopETSImportIfNoDatapoint":"stop","loglevel":"error","name":"KNX Gatewayzzzz","localEchoInTunneling":true,"delaybetweentelegrams":"50","delaybetweentelegramsfurtherdelayREAD":"1","ignoreTelegramsWithRepeatedFlag":false,"autoReconnect":true}]
```

and the DTP docu [Griesser Object.pdf](https://github.com/Supergiovane/node-red-contrib-knx-ultimate/files/9974949/238-10755_10757-13_Griesser.Object__d.1.1.pdf).

