### PR TITLE
Respect default hostProtocol correctly

### DIFF
--- a/nodes/knxUltimate-config.js
+++ b/nodes/knxUltimate-config.js
@@ -107,7 +107,7 @@ module.exports = (RED) => {
     // 15/12/2021
 
     // 05/12/2021 Set the protocol (this is undefined if coming from ild versions
-    if (config.hostProtocol === "Auto") {
+    if (node.hostProtocol === "Auto") {
       // Auto set protocol based on IP
       if (
         node.host.startsWith("224.") ||


### PR DESCRIPTION
This fixes an issue which appears when updating from earlier version (skipping version in between), leading to config nodes not having `config.hostProtocol` set to "Auto" but to nothing at all. There's a fallback to "Auto" but this doesn't help currently because the check further down refers to the unchanged `config.hostProtocol` value, whereas the default is written to `node.hostProtocol`.

Without this fix existing nodes won't connect and report an "socket not set on client" error in the logs. 