### PR TITLE
fix(hue): handle upward DPT 3 break telegrams

### DIFF
--- a/nodes/knxUltimateHueLight.js
+++ b/nodes/knxUltimateHueLight.js
@@ -750,7 +750,9 @@ module.exports = function (RED) {
         let numStep = 10 // Steps from 0 to 100 by 10
         const extendedConf = {}
 
-        if (_KNXbrightness_Direction === 0 && _KNXaction === 0) {
+        // DPT 3.x uses data/step-code 0 for BREAK. The direction bit may be
+        // either 0 ($00) or 1 ($08), so it must not be part of this check.
+        if (_KNXbrightness_Direction === 0) {
           // STOP DIM
           if (node.timerStepDim !== undefined) clearInterval(node.timerStepDim)
           node.brightnessStep = null
@@ -835,7 +837,7 @@ module.exports = function (RED) {
       // 23/23/2023 after many attempts to use dimming_delta function of the HueApeV2, loosing days of my life, without a decent success, will use the standard dimming calculations
       // i decide to go to the "step brightness" way.
       try {
-        if (_KNXbrightness_DirectionTunableWhite === 0 && _KNXaction === 0) {
+        if (_KNXbrightness_DirectionTunableWhite === 0) {
           // STOP DIM
           if (node.timerStepDimTunableWhite !== undefined) clearInterval(node.timerStepDimTunableWhite)
           node.brightnessStepTunableWhite = null
@@ -909,7 +911,7 @@ module.exports = function (RED) {
       // After many attempts to use dimming_delta function of the HueApiV2, loosing days of my life, without a decent success, will use the standard dimming calculations
       // i decide to go to the "step brightness" way.
       try {
-        if (_KNXbrightness_DirectionHSV_H === 0 && _KNXaction === 0) {
+        if (_KNXbrightness_DirectionHSV_H === 0) {
           // STOP DIM
           if (node.timerStepDimHSV_H !== undefined) clearInterval(node.timerStepDimHSV_H)
           node.deleteHueStateQueue() // Clear dimming queue.
@@ -997,7 +999,7 @@ module.exports = function (RED) {
       // After many attempts to use dimming_delta function of the HueApiV2, loosing days of my life, without a decent success, will use the standard dimming calculations
       // i decide to go to the "step brightness" way.
       try {
-        if (_KNXbrightness_DirectionHSV_S === 0 && _KNXaction === 0) {
+        if (_KNXbrightness_DirectionHSV_S === 0) {
           // STOP DIM
           if (node.timerStepDimHSV_S !== undefined) clearInterval(node.timerStepDimHSV_S)
           node.deleteHueStateQueue() // Clear dimming queue.

--- a/nodes/utils/hueControllerProfiles/runtime/light.js
+++ b/nodes/utils/hueControllerProfiles/runtime/light.js
@@ -753,7 +753,9 @@ module.exports = function (RED) {
         let numStep = 10 // Steps from 0 to 100 by 10
         const extendedConf = {}
 
-        if (_KNXbrightness_Direction === 0 && _KNXaction === 0) {
+        // DPT 3.x uses data/step-code 0 for BREAK. The direction bit may be
+        // either 0 ($00) or 1 ($08), so it must not be part of this check.
+        if (_KNXbrightness_Direction === 0) {
           // STOP DIM
           if (node.timerStepDim !== undefined) clearInterval(node.timerStepDim)
           node.brightnessStep = null
@@ -838,7 +840,7 @@ module.exports = function (RED) {
       // 23/23/2023 after many attempts to use dimming_delta function of the HueApeV2, loosing days of my life, without a decent success, will use the standard dimming calculations
       // i decide to go to the "step brightness" way.
       try {
-        if (_KNXbrightness_DirectionTunableWhite === 0 && _KNXaction === 0) {
+        if (_KNXbrightness_DirectionTunableWhite === 0) {
           // STOP DIM
           if (node.timerStepDimTunableWhite !== undefined) clearInterval(node.timerStepDimTunableWhite)
           node.brightnessStepTunableWhite = null
@@ -912,7 +914,7 @@ module.exports = function (RED) {
       // After many attempts to use dimming_delta function of the HueApiV2, loosing days of my life, without a decent success, will use the standard dimming calculations
       // i decide to go to the "step brightness" way.
       try {
-        if (_KNXbrightness_DirectionHSV_H === 0 && _KNXaction === 0) {
+        if (_KNXbrightness_DirectionHSV_H === 0) {
           // STOP DIM
           if (node.timerStepDimHSV_H !== undefined) clearInterval(node.timerStepDimHSV_H)
           node.deleteHueStateQueue() // Clear dimming queue.
@@ -1000,7 +1002,7 @@ module.exports = function (RED) {
       // After many attempts to use dimming_delta function of the HueApiV2, loosing days of my life, without a decent success, will use the standard dimming calculations
       // i decide to go to the "step brightness" way.
       try {
-        if (_KNXbrightness_DirectionHSV_S === 0 && _KNXaction === 0) {
+        if (_KNXbrightness_DirectionHSV_S === 0) {
           // STOP DIM
           if (node.timerStepDimHSV_S !== undefined) clearInterval(node.timerStepDimHSV_S)
           node.deleteHueStateQueue() // Clear dimming queue.

--- a/test/knxUltimateHueLight.test.js
+++ b/test/knxUltimateHueLight.test.js
@@ -276,6 +276,33 @@ describe('knxUltimateHueLight KNX to HUE routing', () => {
     expect(hueCommands).to.have.lengthOf(0)
   })
 
+  it('stops upward relative dimming on DPT 3.007 BREAK ($08)', () => {
+    withFakeTimers(({ tick, activeIntervals }) => {
+      const { node, config, hueCommands, hueQueueDeletes } = instantiateNode({
+        GALightDIM: '1/1/3',
+        dptLightDIM: '3.007',
+        dimSpeed: 1000
+      })
+
+      node.currentHUEDevice = {
+        on: { on: true },
+        dimming: { brightness: 50 }
+      }
+
+      node.handleSend(createSwitchTelegram(config.GALightDIM, 0x09))
+      expect(activeIntervals).to.have.lengthOf(1)
+      tick()
+      hueCommands.length = 0
+
+      node.handleSend(createSwitchTelegram(config.GALightDIM, 0x08))
+
+      expect(hueQueueDeletes).to.deep.equal(['test-light'])
+      expect(node.brightnessStep).to.equal(null)
+      expect(activeIntervals).to.have.lengthOf(0)
+      expect(hueCommands).to.have.lengthOf(0)
+    })
+  })
+
   it('does not update the local kelvin cache from KNX writes unless enabled', () => {
     const { node, config, hueCommands } = instantiateNode({
       GALightKelvin: '1/1/6',
@@ -757,7 +784,7 @@ describe('knxUltimateHueLight dimming helpers', () => {
     })
   })
 
-  it('clears timers and queue when dimming stop telegram arrives', () => {
+  it('clears timers and queue when upward dimming BREAK ($08) arrives', () => {
     withFakeTimers(({ tick, activeIntervals }) => {
       const { node, hueCommands, hueQueueDeletes } = instantiateNode()
 
@@ -770,7 +797,7 @@ describe('knxUltimateHueLight dimming helpers', () => {
       tick()
       hueCommands.length = 0
 
-      node.hueDimming(0, 0, 1000)
+      node.hueDimming(1, 0, 1000)
 
       expect(hueQueueDeletes).to.deep.equal(['test-light'])
       expect(node.brightnessStep).to.equal(null)
@@ -814,7 +841,7 @@ describe('knxUltimateHueLight dimming helpers', () => {
     })
   })
 
-  it('stops HSV hue dimming when stop telegram arrives', () => {
+  it('stops HSV hue dimming when upward BREAK ($08) arrives', () => {
     withFakeTimers(({ tick, activeIntervals }) => {
       const { node, hueCommands, hueQueueDeletes } = instantiateNode()
 
@@ -835,7 +862,7 @@ describe('knxUltimateHueLight dimming helpers', () => {
       tick()
       hueCommands.length = 0
 
-      node.hueDimmingHSV_H(0, 0, 1000)
+      node.hueDimmingHSV_H(1, 0, 1000)
 
       expect(hueQueueDeletes[hueQueueDeletes.length - 1]).to.equal('test-light')
       expect(activeIntervals).to.have.lengthOf(0)
@@ -925,7 +952,7 @@ describe('knxUltimateHueLight dimming helpers', () => {
     })
   })
 
-  it('clears queue and resets tunable white step on stop', () => {
+  it('clears queue and resets tunable white step on upward BREAK ($08)', () => {
     withFakeTimers(({ tick, activeIntervals }) => {
       const { node, hueCommands, hueQueueDeletes } = instantiateNode()
 
@@ -939,7 +966,7 @@ describe('knxUltimateHueLight dimming helpers', () => {
       tick()
       hueCommands.length = 0
 
-      node.hueDimmingTunableWhite(0, 0, 1000)
+      node.hueDimmingTunableWhite(1, 0, 1000)
 
       expect(hueQueueDeletes).to.include('test-light')
       expect(activeIntervals).to.have.lengthOf(0)


### PR DESCRIPTION
## Summary

- treat DPT 3.x BREAK as step code `0`, independently of the direction bit
- handle both `$00` (downward BREAK) and `$08` (upward BREAK) in the legacy Hue Light and unified HUE Controller runtimes
- add regression coverage for the `$09` → `$08` upward dimming sequence

## Testing

- `DEBUG_KNX_HUE_TEST=0 npx mocha test/knxUltimateHueLight.test.js` — 41 passing
- `npm run hue-controller:check`
- `node scripts/check-node-load.js`

The full `npm test` run reaches and passes the Hue tests, but the container cannot initialize mDNS for the unrelated Matter tests (`uv_interface_addresses`).

Fixes #523